### PR TITLE
Establish a CONNECT tunnel before trying to write into an SSL context

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -55,6 +55,7 @@ https_tunnel_request(CONN *C, char *host, int port)
     );    
     rlen = strlen(request); 
     echo ("%s", request);
+    C->encrypt = FALSE;
     if ((n = socket_write(C, request, rlen)) != rlen){
       NOTIFY(ERROR, "HTTP: unable to write to socket." );
       return FALSE;


### PR DESCRIPTION
When connecting to an SSL host through a proxy, Siege would attempt to send the CONNECT header using an un-initialized SSL context, which should be sent in plaintext to the proxy. This change will cause Siege to properly create a CONNECT tunnel.
