### PR TITLE
Handle SSL_ERROR_WANT_READ in socket_read

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -443,7 +443,7 @@ socket_read(CONN *C, void *vbuf, size_t len)
 	return -1;
       }
       if ((r = SSL_read(C->ssl, buf, n)) < 0) {
-        if (errno == EINTR)
+        if (errno == EINTR || SSL_get_error(C->ssl, r) == SSL_ERROR_WANT_READ)
           r = 0;
         else
           return -1;


### PR DESCRIPTION
Hi @JoeDog,

I had to patch `siege` to get it working with my server.  I think this patch may be useful to others.

Thanks!

Bo

From `man SSL_get_error`:

> SSL_ERROR_WANT_READ
> The operation did not complete; the same TLS/SSL I/O function should be called again later.