### PR TITLE
This literal '\0' is implictly cast to a pointer, which generates compil...

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -67,7 +67,7 @@ evaluate(HASH hash_table, char *buf)
     if (getenv(string) != NULL) {
       ENV = 1;
     } else {
-      string = '\0'; /* user botched his config file */
+      string = NULL; /* user botched his config file */
     }
   }
  


### PR DESCRIPTION
I appreciate these are quite minor.