### PR TITLE
Prevent segfault with parsing certain content in seigrc

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -259,10 +259,18 @@ load_conf(char *filename)
     while (*optionptr && !ISSPACE((int)*optionptr) && !ISSEPARATOR(*optionptr)) {
       optionptr++;
     }
-    *optionptr++=0;
+    optionptr++;
+    if(!*optionptr) {
+	    continue;
+    }
+    *optionptr=0;
     while (ISSPACE((int)*optionptr) || ISSEPARATOR(*optionptr)) {
       optionptr++;
     }
+    if(!*optionptr) {
+	    continue;
+    }
+
     value = xstrdup(optionptr);
     while (*line)
       line++;  


### PR DESCRIPTION
I've been running some instrumentation to try and identify the memory issue we've been discussing. With AddressSanitizer running, I'm seeing a crash with this backtrace:

#0  0x00007f49ad3f6bb4 in __msan_warning_noreturn ()
#1  0x00007f49ad477f6b in load_conf (filename=<optimized out>) at init.c:263
#2  0x00007f49ad4741b4 in init_config () at init.c:95
#3  0x00007f49ad47edf2 in main (argc=6, argv=0x7ffc75b85e38) at main.c:324

The problem with enumerating a string based on spaces is that if a line ends with a space, the next piece of code involves unallocated memory. Unfortunately, line 399 of the default .siegerc, contains a line ending in a space.

This PR prevents the use of unallocated memory in this scenario.