### PR TITLE
Allow ms delay but do not affect current behavior

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -248,10 +248,15 @@ __http(CONN *C, URL U, CLIENT *client)
     return FALSE;
   }
 
-  if (my.delay) {
+  if (my.delay >= 1) {
     pthread_sleep_np(
      (unsigned int) (((double)pthread_rand_np(&(client->rand_r_SEED)) /
                      ((double)RAND_MAX + 1) * my.delay ) + .5) 
+    );
+  } else if (my.delay >= .001) {
+    pthread_usleep_np(
+     (unsigned int) (((double)pthread_rand_np(&(client->rand_r_SEED)) /
+                     ((double)RAND_MAX + 1) * my.delay * 1000000 ) + .0005) 
     );
   }
 

--- a/src/init.c
+++ b/src/init.c
@@ -172,7 +172,7 @@ show_config(int EXIT)
     printf( "repetitions:                    n/a\n" );
   printf( "socket timeout:                 %d\n", my.timeout );
   printf( "accept-encoding:                %s\n", my.encoding);
-  printf( "delay:                          %d sec%s\n", my.delay,my.delay>1?"s":"" );
+  printf( "delay:                          %.3f sec%s\n", my.delay,my.delay>1?"s":"" );
   printf( "internet simulation:            %s\n", my.internet?"true":"false"  );
   printf( "benchmark mode:                 %s\n", my.bench?"true":"false"  );
   printf( "failures until abort:           %d\n", my.failures );
@@ -350,7 +350,7 @@ load_conf(char *filename)
     }
     else if (strmatch(option, "delay")) {
       if (value != NULL) {
-        my.delay = atoi(value);
+        my.delay = atof(value);
       } else {
         my.delay = 1;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ display_help()
   printf("                            default is used: PREFIX/var/%s.log\n", program_name);
   puts("  -m, --mark=\"text\"         MARK, mark the log file with a string." );
   puts("  -d, --delay=NUM           Time DELAY, random delay before each requst");
-  puts("                            between 1 and NUM. (NOT COUNTED IN STATS)");
+  puts("                            between .001 and NUM. (NOT COUNTED IN STATS)");
   puts("  -H, --header=\"text\"       Add a header to request (can be many)" ); 
   puts("  -A, --user-agent=\"text\"   Sets User-Agent in request" ); 
   puts("  -T, --content-type=\"text\" Sets Content-Type in request" ); 
@@ -216,7 +216,7 @@ parse_cmdline(int argc, char *argv[])
         break;
       case 'd':
 	/* XXX range checking? use strtol? */
-        my.delay   = atoi(optarg);
+        my.delay   = atof(optarg);
 	if(my.delay < 0){
 	  my.delay = 0; 
 	}

--- a/src/setup.h
+++ b/src/setup.h
@@ -162,7 +162,7 @@ struct CONFIG
   BOOLEAN display;      /* boolean, display the thread id verbose  */
   BOOLEAN config;       /* boolean, prints the configuration       */
   int     cusers;       /* default concurrent users value.         */
-  int     delay;        /* range for random time delay, see -d     */
+  float   delay;        /* range for random time delay, see -d     */
   int     timeout;      /* socket connection timeout value, def:10 */
   BOOLEAN bench;        /* signifies a benchmarking run, no delay  */
   BOOLEAN internet;     /* use random URL selection if TRUE        */


### PR DESCRIPTION
We are load testing an app server with expected average response time less than 4ms and needed a finer grained value for delay. Delay was changed to a float and the client sleep time became more granular for delay values < 1.