### PR TITLE
Segfault when POST data contains null

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -183,12 +183,8 @@ void
 url_set_postdata(URL this, char *postdata, size_t postlen)
 {
   this->postlen = postlen;
-
-  if (strlen(postdata) > 0) {
-    this->postdata = malloc(this->postlen);
-    memcpy(this->postdata, postdata, this->postlen);
-    this->postdata[this->postlen] = 0;
-  }
+  this->postdata = malloc(this->postlen);
+  memcpy(this->postdata, postdata, this->postlen);
   return;
 }
 


### PR DESCRIPTION
This change fixes a bug which causes a SEGFAULT when the POST data read from a file contains a null byte.