### PR TITLE
Fix buffer overflow while reading post data.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -266,6 +266,7 @@ load_file(URL U, char *file)
 
   if ((fread(buf, 1, len, fp )) == len) {
     if (is_ascii(filename)) {
+      buf[len] = '\0';
       trim(buf);
       len = strlen(buf);
     }


### PR DESCRIPTION
fread reads data as binary data, and does not append a null char at the
end of the buffer.