### PR TITLE
Added support of content type application/x-protobuf

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -203,7 +203,8 @@ static const struct ContentType tmap[] = {
   {"xpm",     FALSE, "image/x-xpixmap"},
   {"xwd",     FALSE, "image/x-xwindowdump"},
   {"xyz",     FALSE, "chemical/x-pdb"},
-  {"zip",     FALSE, "application/zip"}
+  {"zip",     FALSE, "application/zip"},
+  {"proto",   FALSE, "application/x-protobuf"}
 };
 
 char * 


### PR DESCRIPTION
Added support for  posting  protobuf files through siege. We set Content-Type:application/x-protobuf when file in the POST has .proto extension.  