### PR TITLE
rename itoa to fix build on x86_64-pc-msys

### DIFF
--- a/include/joedog/joedog.h
+++ b/include/joedog/joedog.h
@@ -63,7 +63,7 @@ void xfree(void *ptr);
 /**
  * Utility functions
  */
-void  itoa(int, char []);
+void  my_itoa(int, char []);
 void  reverse(char []);
 int   my_random(int, int);
 char  *substring(char *, int, int);

--- a/lib/joedog/util.c
+++ b/lib/joedog/util.c
@@ -73,7 +73,7 @@ my_random( int max, int seed )
 }
 
 void 
-itoa( int n, char s[] )
+my_itoa( int n, char s[] )
 {
   int i, sign;
   if(( sign = n ) < 0 )

--- a/lib/joedog/util.h
+++ b/lib/joedog/util.h
@@ -63,7 +63,7 @@ char *strchr (), *strrchr ();
 #include <unistd.h>
 #include "memory.h"
 
-void   itoa(int, char []);
+void   my_itoa(int, char []);
 void   reverse(char []);
 int    my_random(int, int);
 char   *substring(char *, int, int);


### PR DESCRIPTION
I use grep find 'itoa' where is used  
```
./include/joedog/joedog.h:66:void  itoa(int, char []);
./lib/joedog/util.c:76:itoa( int n, char s[] )
./lib/joedog/util.h:66:void   itoa(int, char []);
```
But , When I build siege on [MSYS2](http://msys2.github.io/) , it's failed, when I comment out those, After build  and run success,so I rename itoa ,test it on Windows and linux success.