### PR TITLE
Fixed error that the request maybe include the post data in URL file.

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -529,9 +529,11 @@ __url_parse(URL this, char *url)
   if (post != NULL){
     if (!strncasecmp(post," PUT", 4)) {
       this->method = PUT;
+      *post = '\0';
       post += 4;
     } else {
       this->method = POST;
+      *post = '\0';
       post += 5;
     }
     __parse_post_data(this, post);

--- a/src/url.c
+++ b/src/url.c
@@ -827,7 +827,6 @@ __url_set_path(URL this, char *str)
   } else {
     this->path    = xmalloc(i+2);
     memcpy(this->path, str, i+1);
-    memcpy(this->request, str, j+1);
     this->path[i] = '/';
     this->path[i + 1]    = '\0';
   }


### PR DESCRIPTION
If the request below was in URL file, the request would contained the post data after the request.
```plain
http://example.com/foobar PUSH foo=1&bar=2
```