### PR TITLE
Include sys/types.h in src/hash.c

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -23,6 +23,8 @@
 # include <config.h>
 #endif/*HAVE_CONFIG_H*/
 
+#include <sys/types.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Include sys/types.h in src/hash.c, otherwise during make you can receive a unknown type name error for u_int32_t. To recreate follow the steps below:

1. docker run --rm -it alpine sh
2. Add the build dependencies: apk add --update alpine-sdk
3. wget http://download.joedog.org/siege/siege-latest.tar.gz
4. tar -zxvf siege-latest.tar.gz
5. cd siege-3.1.3
6. ./configure
7. make

Once you make the this fix then run:

1. make clean
2. make

Siege will build successfully.