### PR TITLE
Fixed two bugs in Set-Cookie expires parsing

### DIFF
--- a/src/cookie.c
+++ b/src/cookie.c
@@ -391,9 +391,9 @@ __parse_time(const char *str)
         return 0;
       }
       tm.tm_mday = strtol(s, &s, 10);
-      tm.tm_mon  = __mkmonth(s, &s);
+      tm.tm_mon  = __mkmonth(++s, &s);
       tm.tm_year = strtol(++s, &s, 10) - 1900;
-      tm.tm_hour = strtol(s, &s, 10);
+      tm.tm_hour = strtol(++s, &s, 10);
       tm.tm_min  = strtol(++s, &s, 10);
       tm.tm_sec  = strtol(++s, &s, 10);
     } else {  /* Second format */

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -444,7 +444,11 @@ __parse_time(const char *str)
     return 0;
   }
   tm.tm_isdst = -1;
-  rv = mktime(&tm) + __utc_offset() * 3600;
+  rv = mktime(&tm);
+  if (!strstr(str, " GMT") && !strstr(str, " UTC")) {
+  	// It's not zulu time, so assume it's in local time
+	rv += __utc_offset() * 3600;
+  }
 
   if (rv == -1) {
     return rv;


### PR DESCRIPTION
I was seeing Siege fail to send cookies back to the server with this value:

> Set-Cookie: mmsession=533779517852340552090058408281936468; path=/; expires=Sat, 26-Mar-2016 01:38:34 GMT; HttpOnly

That time was 1 hour in the future from the time of the packet capture, but Siege thought it was a bad cookie due to the dashes separating "26-Mar-2016". (That's legal [in RFC6265](http://tools.ietf.org/html/rfc6265#page-14).) Once I'd fixed that, it still failed because of the GMT offset.