### PR TITLE
Fix accept-encoding typo in config template

### DIFF
--- a/doc/siegerc.in
+++ b/doc/siegerc.in
@@ -444,8 +444,8 @@ benchmark = false
 # ex: accept-encoding = 
 #     accept-encoding = gzip
 #     accept-encoding = deflate
-#     accept-encoding = gzip;deflate
-accept-encoding = gzip;deflate
+#     accept-encoding = gzip, deflate
+accept-encoding = gzip, deflate
 
 #
 # URL escaping was first added to version 3.0.3. It was considered


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7231#section-5.3.1 and https://tools.ietf.org/html/rfc7231#section-5.3.4

The "Quality Values" for "Accept-Encoding" header encoding type are separated by ",", whereas ";" is used to specify encoding weight.

So, "gzip;deflate" is actually not valid, and some rigid webservers like IIS will reject such request with 400.

