### PR TITLE
Switch to BSD compliant format

### DIFF
--- a/utils/bombardment.in
+++ b/utils/bombardment.in
@@ -40,7 +40,7 @@ startcl=$2
 inc=$3
 numruns=$4
 delay=$5
-serial=`date --iso-8601=minutes`
+serial=`date '+%Y-%m-%dT%H:%M%z'`
 
 # This script can easily be made to overwhelm system resources (processes
 # and filehandles.  This bit calculates how many processes it will spawn


### PR DESCRIPTION
This commit switches from the GNU specific ISO-8601 flag to a BSD
compatible format.