### PR TITLE
Improve precision in the output timings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config.log
 include/config.h
 include/config.h.in
 include/joedog/joepath.h
+include/joedog/path.h
 include/stamp-h1
 lib/joedog/.libs/
 lib/joedog/libjoedog.la
@@ -22,10 +23,14 @@ src/siege
 
 # Generated
 doc/bombardment.1
+doc/bombardment.1.in
 doc/layingsiege.7
 doc/siege.1
+doc/siege.1.in
 doc/siege.config.1
+doc/siege.config.1.in
 doc/siege2csv.1
+doc/siege2csv.1.in
 doc/siegerc
 doc/urls_txt.5
 utils/bombardment

--- a/src/main.c
+++ b/src/main.c
@@ -522,24 +522,24 @@ main(int argc, char *argv[])
       fprintf(stderr, "%s aborted due to excessive socket failure; you\n", program_name);
       fprintf(stderr, "can change the failure threshold in $HOME/.%src\n", program_name);
     }
-    fprintf(stderr, "\nTransactions:\t\t%12u hits\n",        data_get_count(data));
+    fprintf(stderr, "\nTransactions:\t\t%9u    hits\n",        data_get_count(data));
     fprintf(stderr, "Availability:\t\t%12.2f %%\n",          data_get_count(data)==0 ? 0 :
                                                              (double)data_get_count(data) /
                                                              (data_get_count(data)+my.failed)*100
     );
     fprintf(stderr, "Elapsed time:\t\t%12.2f secs\n",        data_get_elapsed(data));
     fprintf(stderr, "Data transferred:\t%12.2f MB\n",        data_get_megabytes(data)); /*%12llu*/
-    fprintf(stderr, "Response time:\t\t%12.2f secs\n",       data_get_response_time(data));
+    fprintf(stderr, "Response time:\t\t%12.2f ms\n",       1000.0f * data_get_response_time(data));
     fprintf(stderr, "Transaction rate:\t%12.2f trans/sec\n", data_get_transaction_rate(data));
     fprintf(stderr, "Throughput:\t\t%12.2f MB/sec\n",        data_get_throughput(data));
     fprintf(stderr, "Concurrency:\t\t%12.2f\n",              data_get_concurrency(data));
-    fprintf(stderr, "Successful transactions:%12u\n",        data_get_code(data)); 
+    fprintf(stderr, "Successful transactions:%9u\n",        data_get_code(data));
     if (my.debug) {
-      fprintf(stderr, "HTTP OK received:\t%12u\n",             data_get_okay(data));
+      fprintf(stderr, "HTTP OK received:\t%9u\n",             data_get_okay(data));
     }
-    fprintf(stderr, "Failed transactions:\t%12u\n",          my.failed);
-    fprintf(stderr, "Longest transaction:\t%12.2f\n",        data_get_highest(data));
-    fprintf(stderr, "Shortest transaction:\t%12.2f\n",       data_get_lowest(data));
+    fprintf(stderr, "Failed transactions:\t%9u\n",          my.failed);
+    fprintf(stderr, "Longest transaction:\t%12.2f ms\n",        1000.0f * data_get_highest(data));
+    fprintf(stderr, "Shortest transaction:\t%12.2f ms\n",       1000.0f * data_get_lowest(data));
     fprintf(stderr, " \n");
   }
   if (my.mark)    mark_log_file(my.markstr);


### PR DESCRIPTION
This fixes up some missing gitignore rules and shows transactions times in milliseconds rather than seconds:

    ** SIEGE 4.0.3rc3
    ** Preparing 1 concurrent users for battle.
    The server is now under siege...
    Lifting the server siege...
    Transactions:                2180    hits
    Availability:                 100.00 %
    Elapsed time:                   9.70 secs
    Data transferred:               0.88 MB
    Response time:                  4.36 ms
    Transaction rate:             224.74 trans/sec
    Throughput:                     0.09 MB/sec
    Concurrency:                    0.98
    Successful transactions:     2180
    Failed transactions:            0
    Longest transaction:           20.00 ms
    Shortest transaction:           0.00 ms
