### PR TITLE
Fix set non-blocking function

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -371,7 +371,7 @@ __socket_block(int sock, BOOLEAN block)
 #else 
   return sock;
 #endif
-return sock;
+// return sock;
   if (sock==-1) {
     return sock;
   }


### PR DESCRIPTION
Hi, JoeDog, I read the source code recently and there is something confused.
It seems that the function __socket_block always returns sock at the beginning of function without setting the sock's property and this function doesn't do what it should do (set the socket to non-block or block depend on the second parameter.)
I don't know whether it's a feature or a mistake, but I find that the timeout setting is not effective due to that. 
Besides, I'm confused with the line 243-254 in sock.c file. In my opinion, __socket_check returns TRUE means the socket is connected successfully and ready to write, so why we need reconnect?