### PR TITLE
Implement IPv6 support

### DIFF
--- a/src/sock.c
+++ b/src/sock.c
@@ -72,6 +72,7 @@ private ssize_t __socket_write(int sock, const void *vbuf, size_t len);
 private BOOLEAN __socket_check(CONN *C, SDSET mode);
 private BOOLEAN __socket_select(CONN *C, SDSET mode);
 private int     __socket_create(CONN *C, int domain);
+private void   __hostname_strip(char *hn, int len);
 #ifdef  HAVE_POLL
 private BOOLEAN __socket_poll(CONN *C, SDSET mode);
 #endif/*HAVE_POLL*/
@@ -134,6 +135,7 @@ new_socket(CONN *C, const char *hostparam, int portparam)
     snprintf(hn, sizeof(hn), "%s", hostparam);
     port = portparam;
   }
+  __hostname_strip(hn, 512);
 
   /* sanity check */
   if (port < 1 || port > MAX_PORT_NO) {
@@ -427,6 +429,27 @@ __socket_create(CONN *C, int domain)
   }
 
   return 0;
+}
+
+/**
+ * remove square bracket
+ * around IPv6 addresses
+ */
+private void
+__hostname_strip(char *hn, int len)
+{
+  int i;
+
+  if (startswith("[", hn)) {
+    memmove(hn, hn + 1, len - 1);
+
+    /* skip to matching square bracket */
+    for (i = 0; hn[i] && hn[i] != ']'; i++);
+
+    if (hn[i] == ']') {
+      memmove(hn + i, hn + i + 1, len - i - 1);
+    }
+  }
 }
 
 /**

--- a/src/url.c
+++ b/src/url.c
@@ -847,8 +847,22 @@ __url_set_hostname(URL this, char *str)
     memmove(str, str+n, len - n + 1);
   }
 
-  /* skip to end, slash, or port colon */
-  for (i = 0; str[i] && str[i] != '/' && str[i] != '#' && str[i] != ':'; i++);
+  /**
+   * Check for IPv6 address. The convention here is to use square brackets
+   * around the IPv6 address in order to have a clear delimitation between
+   * address and port
+   */
+  if (startswith("[", str)) {
+    /* skip to matching square bracket */
+    for (i = 0; str[i] && str[i] != ']'; i++);
+
+    if (str[i] == ']') {
+      i++;
+    }
+  } else {
+    /* skip to end, slash, or port colon */
+    for (i = 0; str[i] && str[i] != '/' && str[i] != '#' && str[i] != ':'; i++);
+  }
 
   this->hostname = xmalloc(i + 1);
   memset(this->hostname, '\0', i+1);


### PR DESCRIPTION
Implemented IPv6 support in src/sock.c. The main modification that needed to be made for this was to replace the deprecated gethostbyname_r with getaddrinfo for platforms that have GLIBC.