### PR TITLE
Avoid crash at cleanup

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -221,7 +221,6 @@ SSL_thread_cleanup(void)
     OPENSSL_free(lock_count); 
     lock_count=(long *)NULL; 
   }
-  sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
   CRYPTO_cleanup_all_ex_data();
   ERR_remove_state(0);
   ERR_free_strings();


### PR DESCRIPTION
This small patch [Debian issue #865502](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=865502). Please see there for more information.

This change probably leads to a small memory leak. Since it occurs when the program finishes this may not be a serious problem.