### PR TITLE
Remove needless memset(2)

### DIFF
--- a/src/page.c
+++ b/src/page.c
@@ -23,7 +23,6 @@ new_page(char *str)
   this->len  = strlen(str);
   this->size = this->len + 24576;
   this->buf = calloc(1,   this->size);
-  memset(this->buf, '\0', this->size);
   memcpy(this->buf,  str, this->len);
  
   return this;


### PR DESCRIPTION
You use `calloc(3)` to allocate the buffer, so there's no need to zero it. Compilers typically don't catch this IMO, so it can actually harm performance.