### PR TITLE
handle case of incorrect server response header

### DIFF
--- a/src/response.c
+++ b/src/response.c
@@ -173,8 +173,10 @@ response_set_content_type(RESPONSE this, char *line) {
   if (strstr(line, ";") != NULL) {
     ptr  = line+(strlen(CONTENT_TYPE)+2);
     type = strtok_r(ptr, ";", &aid);
-    hash_add(this->headers, CONTENT_TYPE, type);
-    res = TRUE;
+    if (type != NULL) {
+      hash_add(this->headers, CONTENT_TYPE, type);
+      res = TRUE;
+    }
 
     /** 
      * We found a ';', do we have a charset?


### PR DESCRIPTION
handling of incorrect server responses, siege should not sigsegv on strlen(NULL)

```
(gdb) bt
#0 strlen () at ../sysdeps/x86_64/strlen.S:106
0000001 0x000055f5553f8266 in hash_add (this=0x7fbb94001e60, key=key@entry=0x55f5554058f7 "content-type", val=0x0) at hash.c:116
0000002 0x000055f5553ffc66 in response_set_content_type (this=this@entry=0x7fbb94001e10, line=line@entry=0x7fbbc658ecc0 "Content-Type: ;") at response.c:176
0000003 0x000055f5553fa1dd in http_read_headers (C=0x7fbb940008c0, U=U@entry=0x55f5596d3f80) at http.c:465
```