### PR TITLE
Fix segfault when siege exits after hitting SSL server

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -221,16 +221,15 @@ SSL_thread_cleanup(void)
     OPENSSL_free(lock_count); 
     lock_count=(long *)NULL; 
   }
-  sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
-  CRYPTO_cleanup_all_ex_data();
-  ERR_remove_state(0);
   ERR_free_strings();
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED)
+#if (OPENSSL_VERSION_NUMBER < 0x10000000L) || defined(OPENSSL_USE_DEPRECATED)
    ERR_remove_state(0);
-#else
+#endif
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(OPENSSL_USE_DEPRECATED)
    ERR_remove_thread_state(NULL);
+   SSL_COMP_free_compression_methods();
 #endif
 }
 


### PR DESCRIPTION
Addresses https://github.com/JoeDog/siege/issues/109 for siege 4.0.2

This does seem to conflict with master, which has its own fix (but doesn't have the SSL_COMP_free_compression_methods() call). 