### PR TITLE
#162 Fix for handling XML in POST line

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -643,7 +643,7 @@ __parse_post_data(URL this, char *datap)
   for (; isspace((unsigned int)*datap); datap++) {
     /* Advance past white space */
   }
-  if (*datap == '<') {
+  if (*datap == '<' && *(datap+1) != '?') {
     datap++;
     load_file(this, datap);
     datap = __url_set_path(this, datap);


### PR DESCRIPTION
The idea with this change is to realize that `POST <` does not automatically mean we are reading a file for input. Instead we check to see if the character following is the start of an XML declaration such as `<?xml ... ?>`