### PR TITLE
Add option to output the final stats in JSON to stdout

### DIFF
--- a/doc/siegerc.in
+++ b/doc/siegerc.in
@@ -540,6 +540,16 @@ url-escaping = true
 unique = true
 
 #
+# JSON output - With this feature enabled, siege will print the final stats as
+# JSON to stdout. It monopolizes stdout, superceding verbose and debug modes.
+#
+# The default value is false.
+#
+# ex: json_output = true | false
+#
+json_output = false
+
+#
 # SSL-cert: This optional feature allows you to specify a path to a client
 # certificate. It is not neccessary to specify a certificate in order to use
 # https. If you don't know why you would want one, then you probably don't need

--- a/doc/siegerc.in
+++ b/doc/siegerc.in
@@ -541,7 +541,7 @@ unique = true
 
 #
 # JSON output - With this feature enabled, siege will print the final stats as
-# JSON to stdout. It monopolizes stdout, superceding verbose and debug modes.
+# JSON to stdout. Setting this to true implies quiet mode.
 #
 # The default value is false.
 #

--- a/src/init.c
+++ b/src/init.c
@@ -689,16 +689,7 @@ ds_module_check(void)
   }
 
   if (my.json_output) {
-    if (my.verbose) {
-      my.verbose = FALSE;
-      if (!my.quiet)
-        fprintf(stderr, "Verbose mode is disabled for JSON output.\n");
-    }
-    if (my.debug) {
-      my.debug = FALSE;
-      if (!my.quiet)
-        fprintf(stderr, "Debug mode is disabled for JSON output.\n");
-    }
+    my.quiet = TRUE;
   }
 
   if (my.quiet) {

--- a/src/init.c
+++ b/src/init.c
@@ -690,12 +690,14 @@ ds_module_check(void)
 
   if (my.json_output) {
     if (my.verbose) {
-      fprintf(stderr, "Verbose mode is disabled for JSON output.\n");
       my.verbose = FALSE;
+      if (!my.quiet)
+        fprintf(stderr, "Verbose mode is disabled for JSON output.\n");
     }
     if (my.debug) {
-      fprintf(stderr, "Debug mode is disabled for JSON output.\n");
       my.debug = FALSE;
+      if (!my.quiet)
+        fprintf(stderr, "Debug mode is disabled for JSON output.\n");
     }
   }
 

--- a/src/init.c
+++ b/src/init.c
@@ -119,6 +119,7 @@ init_config( void )
   my.timestamp      = FALSE;
   my.chunked        = FALSE;
   my.unique         = TRUE;
+  my.json_output    = FALSE;
   my.extra[0]       = 0;
   my.follow         = TRUE;
   my.zero_ok        = TRUE; 
@@ -237,6 +238,7 @@ show_config(int EXIT)
   printf("allow zero byte data:           %s\n", my.zero_ok?"true":"false"); 
   printf("allow chunked encoding:         %s\n", my.chunked?"true":"false"); 
   printf("upload unique files:            %s\n", my.unique?"true":"false"); 
+  printf("json output:                    %s\n", my.json_output?"true":"false");
   if (my.parser == TRUE && my.nomap->index > 0) {
     int i;
     printf("no-follow:\n"); 
@@ -586,6 +588,12 @@ load_conf(char *filename)
       else
         my.unique = FALSE;  
     }
+    else if (strmatch(option, "json_output")) {
+      if (!strncasecmp(value, "true", 4))
+        my.json_output = TRUE;
+      else
+        my.json_output = FALSE;
+    }
     else if (strmatch(option, "header")) {
       if (!strchr(value,':')) NOTIFY(FATAL, "no ':' in http-header");
       if ((strlen(value) + strlen(my.extra) + 3) > 512) NOTIFY(FATAL, "too many headers");
@@ -679,8 +687,19 @@ ds_module_check(void)
     my.logging = FALSE;
     my.bench   = TRUE;
   }
-  
-  if (my.quiet) { 
+
+  if (my.json_output) {
+    if (my.verbose) {
+      fprintf(stderr, "Verbose mode is disabled for JSON output.\n");
+      my.verbose = FALSE;
+    }
+    if (my.debug) {
+      fprintf(stderr, "Debug mode is disabled for JSON output.\n");
+      my.debug = FALSE;
+    }
+  }
+
+  if (my.quiet) {
     my.verbose = FALSE; // Why would you set quiet and verbose???
     my.debug   = FALSE; // why would you set quiet and debug?????
   }

--- a/src/setup.h
+++ b/src/setup.h
@@ -217,6 +217,7 @@ struct CONFIG
   char    *ssl_key;     /* PEM private key file for client auth    */
   char    *ssl_ciphers; /* SSL chiphers to use : delimited         */ 
   METHOD  method;       /* HTTP method for --get requests          */
+  BOOLEAN json_output;  /* boolean, TRUE == print stats in json    */
   pthread_cond_t  cond;
   pthread_mutex_t lock;
 };


### PR DESCRIPTION
I would like to run Siege and interpret the results programmatically, particularly in an automated CI environment. Having the option to print the results as JSON to stdout would make Siege easier to integrate with other scripts and tools.

This PR addresses feature request #151 