### PR TITLE
Allow the command line verbose option to override the configuration file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -256,6 +256,8 @@ parse_cmdline(int argc, char *argv[])
         break;
       case 'v':
         my.verbose = TRUE;
+        my.json_output = FALSE;
+        my.quiet   = FALSE;
         break;
       case 'r':
         if(strmatch(optarg, "once")){


### PR DESCRIPTION
Since the default configuration file has json_output set to true 
( [siegerc.in](https://github.com/JoeDog/siege/blob/master/doc/siegerc.in#L70) )
 and the json_output monopolizes stdout, superceding verbose, 
( [init.c](https://github.com/JoeDog/siege/blob/master/src/init.c#L691-L696) )
 this change allows the user to activate the verbose mode using the command line
parameter even when json_output is set to true in the configuration file.