### PR TITLE
fix: `--reps=once` behaves incorrectly with multiple concurrent connections

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -220,6 +220,7 @@ start(BROWSER this)
 {
   int x;
   int y;
+  int max_y;
   int ret;
   int len; 
   this->conn  = NULL;
@@ -260,6 +261,7 @@ start(BROWSER this)
 
   len = (my.reps == -1) ? (int)array_length(this->urls) : my.reps;
   y   = (my.reps == -1) ? 0 : this->id * (my.length / my.cusers);
+  max_y = (int)array_length(this->urls);
   for (x = 0; x < len; x++, y++) {
     x = ((my.secs > 0) && ((my.reps <= 0)||(my.reps == MAXREPS))) ? 0 : x;
     if (my.internet == TRUE) {
@@ -273,14 +275,14 @@ start(BROWSER this)
        * with clean slate, ie. reset (delete) cookies (eg. to let a new
        * session start)
        */
-      if (y >= my.length) {
+      if (y >= max_y) {
         y = 0;
         if (my.expire) {
           cookies_delete_all(my.cookies);
         }
       }
     }
-    if (y >= my.length || y < 0) {
+    if (y >= max_y || y < 0) {
       y = 0;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -449,15 +449,19 @@ main(int argc, char *argv[])
       /**
        * Scenario: -r once/--reps=once 
        */
-      int   len = (array_length(urls)/my.cusers); 
-      ARRAY tmp = new_array();
-      for (j = 0; j < ((i+1) * len) && j < (int)array_length(urls); j++) {
+      int n_urls = array_length(urls);
+      int per_user = n_urls / my.cusers;
+      int remainder = n_urls % my.cusers;
+      int begin_url = i * per_user + ((i < remainder) ? i : remainder);
+      int end_url = (i + 1) * per_user + ((i < remainder) ? (i + 1) : remainder);
+      ARRAY url_slice = new_array();
+      for (j = begin_url; j < end_url && j < n_urls; j++) {
         URL u = array_get(urls, j);
         if (u != NULL && url_get_hostname(u) != NULL && strlen(url_get_hostname(u)) > 1) {
-          array_npush(tmp, array_get(urls, j), URLSIZE);    
+          array_npush(url_slice, u, URLSIZE);
         }
-      } 
-      browser_set_urls(B, urls);
+      }
+      browser_set_urls(B, url_slice);
     }
     array_npush(browsers, B, BROWSERSIZE);
   }


### PR DESCRIPTION
When multiple concurrent connections are enabled, Siege with the `--reps=once` option will access the given URLs multiple times instead of just once as specified. This happens because Siege feeds the exact same set of URLs to every concurrent connection it creates. Since each benchmarking thread doesn't keep track of whether or not an URL has been accessed by any other threads, this results in the URLs being accessed more than once.

This change aims to correct this behavior so that `--reps=once` would work under all circumstances. It also fixes a few additional bugs that surfaced after fixing the original problem.

To explain the problem in more detail, the code that splits the URLs among individual connections exists, although it's currently not in use due to a regression in adc9b53. The remaining problems involve the logic for that part of the code:

1. The regression also affected how the URLs are split. Instead of splitting the URLs evenly, it now assigns the nth connection an array of URLs that also includes all of the URLs for the (n-1)th connection.
2. The splitting logic misses the last few URLs if the number of URLs aren't divided evenly by the number of concurrent connections. The amount of missed URLs are equal to the remainder of the division.
