### PR TITLE
Include signal.h when compiling on various BSDs

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -39,6 +39,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <stdlib.h>
+#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <signal.h>
+#endif
 
 #define LINESZ 1024
 


### PR DESCRIPTION
On ElectroBSD this fixes:

   cc -DHAVE_CONFIG_H -I. -I../include    -I/include/zlib -I/include -I/usr/local/include/openssl -I/usr/local/include -I/include/zlib -I/include -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS -W -Wall -Wunused-value -DOPENSSL_NO_KRB5  -g -O2 -c -o init.o init.c
   init.c:78:47: error: use of undeclared identifier 'SIGINT'
       if (WIFSIGNALED(ret) && (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT))
                                                 ^
   init.c:78:74: error: use of undeclared identifier 'SIGQUIT'
       if (WIFSIGNALED(ret) && (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT))
                                                                            ^

The FreeBSD port benchmarks/siege has been using a similar
patch (different OS sorting) for several years now.