### PR TITLE
Only send a CONNECT request if the secure connection has not been est…

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -926,7 +926,7 @@ __init_connection(BROWSER this, URL U)
   );
 
   if (url_get_scheme(U) == HTTPS) {
-    if (auth_get_proxy_required(my.auth)) {
+    if (auth_get_proxy_required(my.auth) && this->conn->ssl == NULL) {
       https_tunnel_request(this->conn, url_get_hostname(U), url_get_port(U));
       https_tunnel_response(this->conn);
     }


### PR DESCRIPTION
…ablished yet

Prevents siege from hanging if https requests are being sent
through a proxy with keep-alive enabled:

    [fk@benchmark-vm ~]$ siege --concurrent=1 --reps=2 --benchmark -v "https://www.electrobsd.org/"
    ** SIEGE 4.0.7: debugging enabled

    Copyright (C) 2018 by Jeffrey Fulmer, et al.
    This is free software; see the source for copying conditions.
    There is NO warranty; not even for MERCHANTABILITY or FITNESS
    FOR A PARTICULAR PURPOSE.

    ** Preparing 1 concurrent users for battle.
    The server is now under siege...
    [debug] browser.c:874 attempting connection to 172.16.1.7:8118
    [debug] browser.c:883 creating new socket:     172.16.1.7:8118
    [debug] browser.c:909 good socket connection:  172.16.1.7:8118
    [debug] CONNECT www.electrobsd.org:443 HTTP/1.0
    User-agent: Proxy-User

    HTTP/1.1 200 Connection established

    GET https://www.electrobsd.org:443/ HTTP/1.1
    Host: www.electrobsd.org
    Accept: */*
    Accept-Encoding: gzip, deflate
    User-Agent: Mozilla/5.0 (portbld-amd64-freebsd11.4) Siege/4.0.7
    Connection: keep-alive

    HTTP/1.1 200 OK
    Server: nginx
    Date: Sat, 20 Mar 2021 11:39:37 GMT
    Content-Type: text/html
    Last-Modified: Sun, 23 Aug 2020 16:46:10 GMT
    Transfer-Encoding: chunked
    Connection: keep-alive
    ETag: W/"5f429d52-1fe"
    Content-Encoding: gzip

    [debug] browser.c:874 attempting connection to 172.16.1.7:8118
    [debug] browser.c:909 good socket connection:  172.16.1.7:8118
    [debug] CONNECT www.electrobsd.org:443 HTTP/1.0
    User-agent: Proxy-User

    [debug]

When using Privoxy in https-inspection mode the second unencrypted
CONNECT request results in an error message like:

    12:31:53.428 8027d3200 Error: Receiving data on socket 5 over TLS/SSL failed: error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number

and the connection is closed.