### PR TITLE
Add basic Socks5 proxy support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 To email a contributor remove "DELETE" from the email address.
 (The DELETEs are necessary as this list is published online.)
 
+2022/03/11 Julien Simbola https://github.com/akiuni
+ * src/auth.c			  Added Socks5 proxy support
+ * src/auth.h			  Added Socks5 proxy support
+ * src/browser.c		  Added Socks5 proxy support
+ * src/http.c			  Added Socks5 proxy support
+ * src/init.c			  Added Socks5 proxy support
+ * src/Makefile.am	      Added Socks5 proxy support
+ * doc/siegerc.in	      Added Socks5 proxy support
+
 2021/07/14 Jeffrey Fulmer http://www.joedog.org/support/
  * src/browser.c          Added HTTP response 201 handler
  * src/response.c         Added Content-Location handler

--- a/doc/siegerc.in
+++ b/doc/siegerc.in
@@ -604,6 +604,14 @@ unique = true
 # proxy-port =
 
 #
+# Proxy Socks5: By default siege will attempt to connect to HTTP proxy 
+# (which is the most common way), however, you can enable socks5 proxy
+# with the setting proxy-socks5
+#
+# ex: proxy-socks5 = true
+# proxy-socks5 =
+
+#
 # Proxy-Authenticate: When siege hits a proxy server which requires 
 # username and password authentication, it will this username and 
 # password to the server. The format is username, password and optional

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,7 @@ parser.c   parser.h    \
 perl.c     perl.h      \
 response.c response.h  \
 sock.c     sock.h      \
+socks5.c    socks5.h     \
 ssl.c      ssl.h       \
 stralloc.c stralloc.h  \
 timer.c    timer.h     \

--- a/src/auth.c
+++ b/src/auth.c
@@ -78,10 +78,11 @@ struct AUTH_T {
     unsigned char nonce[8];
   } ntlm;
   struct {
-    BOOLEAN required;   /* boolean, TRUE == use a proxy server.    */
-    char *hostname;     /* hostname for the proxy server.          */
-    int  port;          /* port number for proxysrv                */
-    char *encode;       /* base64 encoded username and password    */
+    BOOLEAN required;   /* boolean, TRUE == use a proxy server.         */
+    BOOLEAN socks5;     /* boolean, TRUE == socks5, FALSE == http proxy */
+    char *hostname;     /* hostname for the proxy server.               */
+    int  port;          /* port number for proxysrv                     */
+    char *encode;       /* base64 encoded username and password         */
   } proxy;
   pthread_mutex_t lock;
 }; 
@@ -397,6 +398,14 @@ auth_get_proxy_required(AUTH this)
   return this->proxy.required;
 }
 
+BOOLEAN
+auth_get_proxy_socks5(AUTH this)
+{
+  if (this == NULL) 
+    return FALSE;
+  return this->proxy.socks5;
+}
+
 char *
 auth_get_proxy_host(AUTH this) 
 {
@@ -413,6 +422,12 @@ void
 auth_set_proxy_required(AUTH this, BOOLEAN required)
 {
   this->proxy.required = required;
+}
+
+void
+auth_set_proxy_socks5(AUTH this, BOOLEAN socks5)
+{
+  this->proxy.socks5 = socks5;
 }
 
 void

--- a/src/auth.h
+++ b/src/auth.h
@@ -45,7 +45,9 @@ BOOLEAN auth_set_ntlm_header(AUTH this, SCHEME scheme, char *header, char *realm
 char *  auth_get_digest_header(AUTH this, SCHEME scheme, DCHLG *chlg, DCRED *cred, const char *meth, const char *uri);
 BOOLEAN auth_set_digest_header(AUTH this, DCHLG **ch, DCRED **cr, unsigned int *rand, char *realm, char *str);
 BOOLEAN auth_get_proxy_required(AUTH this);
+BOOLEAN auth_get_proxy_socks5(AUTH this);
 void    auth_set_proxy_required(AUTH this, BOOLEAN required);
+void    auth_set_proxy_socks5(AUTH this, BOOLEAN socks5);
 char *  auth_get_proxy_host(AUTH this);
 void    auth_set_proxy_host(AUTH this, char *host);
 int     auth_get_proxy_port(AUTH this);

--- a/src/browser.c
+++ b/src/browser.c
@@ -30,6 +30,7 @@
 #include <ssl.h>
 #include <ftp.h>
 #include <http.h>
+#include <socks5.h>
 #include <hash.h>
 #include <array.h>
 #include <util.h>
@@ -925,8 +926,14 @@ __init_connection(BROWSER this, URL U)
     (auth_get_proxy_required(my.auth))?auth_get_proxy_port(my.auth):url_get_port(U)
   );
 
+  if (auth_get_proxy_required(my.auth) && auth_get_proxy_socks5(my.auth)) {
+    if ( !socks5_tunnel_mount(this->conn, url_get_hostname(U), url_get_port(U)) ) {
+      return FALSE;
+    }
+  }
   if (url_get_scheme(U) == HTTPS) {
-    if (auth_get_proxy_required(my.auth)) {
+    // if (auth_get_proxy_required(my.auth)) {
+    if (auth_get_proxy_required(my.auth) && !auth_get_proxy_socks5(my.auth) ) {
       https_tunnel_request(this->conn, url_get_hostname(U), url_get_port(U));
       https_tunnel_response(this->conn);
     }

--- a/src/http.c
+++ b/src/http.c
@@ -58,7 +58,7 @@ https_tunnel_request(CONN *C, char *host, int port)
   size_t  rlen, n;
   char    request[256];
 
-  if (C->encrypt == TRUE && auth_get_proxy_required(my.auth)) {
+  if (C->encrypt == TRUE && auth_get_proxy_required(my.auth) && !auth_get_proxy_socks5(my.auth)) {
     snprintf(
       request, sizeof(request),
       "CONNECT %s:%d HTTP/1.0\015\012"
@@ -133,7 +133,7 @@ http_get(CONN *C, URL U)
   ifmod = cache_get_header(C->cache, C_LAST, U);
 
   /* Request path based on proxy settings */
-  if(auth_get_proxy_required(my.auth)){
+  if(auth_get_proxy_required(my.auth) && !auth_get_proxy_socks5(my.auth) ){
     sprintf(
       fullpath, "%s://%s:%d%s", C->encrypt == FALSE?"http":"https", 
       url_get_hostname(U), url_get_port(U), url_get_request(U)
@@ -291,7 +291,7 @@ http_post(CONN *C, URL U)
   memset(protocol, '\0', sizeof(protocol));
   memset(keepalive,'\0', sizeof(keepalive));
 
-  if (auth_get_proxy_required(my.auth)) {
+  if (auth_get_proxy_required(my.auth) && !auth_get_proxy_socks5(my.auth)) {
    sprintf(
       fullpath, 
       "%s://%s:%d%s", 

--- a/src/init.c
+++ b/src/init.c
@@ -115,6 +115,7 @@ init_config( void )
   my.auth           = new_auth();
   auth_set_proxy_required(my.auth, FALSE);
   auth_set_proxy_port(my.auth, 3128);
+  auth_set_proxy_socks5(my.auth, FALSE);
   my.timeout        = 30;
   my.timestamp      = FALSE;
   my.chunked        = FALSE;
@@ -208,6 +209,7 @@ show_config(int EXIT)
   if (auth_get_proxy_required(my.auth)){
     printf("proxy-host:                     %s\n", auth_get_proxy_host(my.auth));
     printf("proxy-port:                     %d\n", auth_get_proxy_port(my.auth));
+    printf("proxy-socks5:                   %s\n", auth_get_proxy_socks5(my.auth) ? "true" : "false");
   }
   printf("connection:                     %s\n", my.keepalive?"keep-alive":"close");
   printf("concurrent users:               %d\n", my.cusers);
@@ -570,6 +572,12 @@ load_conf(char *filename)
     }
     else if (strmatch(option, "proxy-host")) {
       auth_set_proxy_host(my.auth, trim(value));
+    }
+    else if (strmatch(option, "proxy-socks5")) {
+      if (!strncasecmp(value, "true", 4))
+        auth_set_proxy_socks5(my.auth, TRUE);
+      else
+        auth_set_proxy_socks5(my.auth, FALSE);
     }
     else if (strmatch(option, "proxy-port")) {
       if (value != NULL) {


### PR DESCRIPTION
This PR aims at allowing usage of siege behind a basic SOCKS5 proxy. If approved, GSSAPI authentication should be added in order to be compliant with rfc1928.

Note that I've used existing proxy-* directives to avoid too many modifications, but it is possible to create dedicated ones for socks5, depending on the maintener willing.

Here is an example of usage behind tor (in default mode, which is socks5 proxy) :
build and run tor:
```
git clone https://github.com/torproject/tor
cd tor
./autogen.sh
./configure --disable-asciidoc
make
./src/app/tor
```

build siege as usual (wish openssl support) and activate socks5 in the siegerc file (9050 is the default socks5 port):
```
proxy-host = localhost
proxy-port = 9050
proxy-socks5 = true
```

Run siege as usual

