### PR TITLE
Bump header size from 2048 to 8192

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -610,7 +610,8 @@ load_conf(char *filename)
     }
     else if (strmatch(option, "header")) {
       if (!strchr(value,':')) NOTIFY(FATAL, "no ':' in http-header");
-      if ((strlen(value) + strlen(my.extra) + 3) > 512) NOTIFY(FATAL, "too many headers");
+      if ((strlen(value) + strlen(my.extra) + 3) > sizeof(my.extra) / 2) // leave half of the header space to be used internally
+          NOTIFY(FATAL, "too many headers");
       strcat(my.extra,value);
       strcat(my.extra,"\015\012");
     }

--- a/src/main.c
+++ b/src/main.c
@@ -293,7 +293,7 @@ parse_cmdline(int argc, char *argv[])
       case 'H':
         {
           if(!strchr(optarg,':')) NOTIFY(FATAL, "no ':' in http-header");
-          if((strlen(optarg) + strlen(my.extra) + 3) > 2048)
+          if((strlen(optarg) + strlen(my.extra) + 3) > sizeof(my.extra))  // sizeof(*my.extra) == 1, so this is accurate
               NOTIFY(FATAL, "header is too large");
           strcat(my.extra,optarg);
           strcat(my.extra,"\015\012");

--- a/src/setup.h
+++ b/src/setup.h
@@ -191,7 +191,7 @@ struct CONFIG
   AUTH auth;
   BOOLEAN keepalive;     /* boolean, connection keep-alive value    */
   int     signaled;      /* timed based testing notification bool.  */
-  char    extra[2048];   /* extra http request headers              */ 
+  char    extra[8192];   /* extra http request headers              */ 
   #if 0
   struct {
     BOOLEAN required;    /* boolean, TRUE == use a proxy server.    */


### PR DESCRIPTION
- Update `setup.h` to change the size
- Update `main.c` to check the size rather than use a hard coded value
- Update `init.c` to check the size and offer half to the config; this allows command line arguments and internals to have space to add any additional needed headers to the request

Hopefully these updated values will be enough to handle users' needs well into the future.