### PR TITLE
Fix build on NetBSD, FreeBSD, OpenBSD & DragonFlyBSD

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -39,6 +39,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <stdlib.h>
+#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#include <signal.h>
+#endif
 
 #define LINESZ 1024
 


### PR DESCRIPTION
On *BSD systems <signal.h> must be included to use signal constants.

(It most likely could be unconditionally included on all systems)