### PR TITLE
Fix bindir value in Autotools script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -481,7 +481,7 @@ AC_OUTPUT_COMMANDS([
   echo "exit"     >> $outfile
   echo ""         >> $outfile
  
-], [ bindir=$exec_prefix$bindir sh=$SHELL ]) 
+], [ bindir=$bindir sh=$SHELL ])
 
 dnl
 dnl create bombardment utility
@@ -494,7 +494,7 @@ AC_OUTPUT_COMMANDS([
       -e "s|%_SHELL%|$sh|" \
       < $infile > $outfile
  
-], [ bindir=$exec_prefix$bindir sh=$SHELL ]) 
+], [ bindir=$bindir sh=$SHELL ])
 
 dnl
 dnl create siege2csv utility
@@ -507,7 +507,7 @@ AC_OUTPUT_COMMANDS([
       -e "s|%_PERL%|$LREP|" \
       < $infile > $outfile
  
-], [ bindir=$exec_prefix$bindir LREP=$PERL ]) 
+], [ bindir=$bindir LREP=$PERL ])
 
 dnl
 dnl Write platform to file for support reporting


### PR DESCRIPTION
I believe, the `configure.ac` has obsolete `bindir` values passing, which leads to e.g. invalid paths (`/usr/usr/bin/siege`) inside of  `bombardment` script. This improvement should fix this issue.

See a [report](https://bugzilla.redhat.com/show_bug.cgi?id=2256670) for siege package in Fedora, for example.