### PR TITLE
Fix segmentation fault on NULL auth algorithm, and use MD5 as default

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -1115,6 +1115,12 @@ __digest_challenge(const char *challenge)
     xfree(key);
   }
 
+  /* Use default MD5 algorithm if not present in the header */
+  if (NULL == result->algorithm)
+  {
+    result->algorithm = strdup("MD5");
+  }
+
   return result;
 }
 


### PR DESCRIPTION
    Some WWW-Authenticate headers don't inform about the algorithm:
    WWW-Authenticate: Digest realm="...", qop="auth", nonce="MT...Zg=="
    
    According to RFC 2617, page 8:
    algorithm
         A string indicating a pair of algorithms used to produce the digest
         and a checksum. If this is not present it is assumed to be "MD5".
