### PR TITLE
set default cookie domain to host

### DIFF
--- a/src/cookie.c
+++ b/src/cookie.c
@@ -497,7 +497,8 @@ __parse_input(COOKIE this, char *hdr, char *host)
     this->expires = expires_candidate;
   }
 
-  if (cookie_get_domain(this) == NULL) {
+  const char *domain = cookie_get_domain(this);
+  if (domain == NULL || domain == __cookie_none) {
     cookie_set_domain(this, host);
     cookie_set_hostonly(this, TRUE);
   }


### PR DESCRIPTION
Check for `domain` to be `NULL` or `__cookie_none` when setting default cookie domain to 
`host`. Without this fix, cookies without a domain from `login-url` are not used with siege URLs.