### PR TITLE
disable keep-alive if server sends Connection: close

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -583,7 +583,7 @@ __http(BROWSER this, URL U)
   /**
    * close the socket and free memory.
    */
-  if (!my.keepalive) {
+  if (!my.keepalive || !this->conn->connection.reuse) {
     socket_close(this->conn);
   }
 

--- a/src/http.c
+++ b/src/http.c
@@ -480,6 +480,8 @@ http_read_headers(CONN *C, URL U, FACTS facts)
     }
     if (strncasecmp(line, CONNECTION, strlen(CONNECTION)) == 0) {
       response_set_connection(resp, line);
+      if (response_get_connection(resp) == CLOSE)
+        C->connection.reuse = 0;
     }
     if (strncasecmp(line, "keep-alive: ", 12) == 0) {
       if (response_set_keepalive(resp, line) == TRUE) {


### PR DESCRIPTION
disable keep-alive if server sends `Connection: close`

servers may have a limit on the number of keep-alive requests before closing a connection and siege should be prepared to handle receiving `Connection: close` from server.