### PR TITLE
Fix bindir value missing exec_prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -499,7 +499,7 @@ AC_CONFIG_COMMANDS([default-1],[[
 
 #endif/*JOEDOG_PATH_H*/
 _EOF_
-]],[[ prefix=$prefix sysconfdir=$sysconfdir localstatedir=$localstatedir platform=$PLATFORM ]])
+]],[[ prefix=$prefix exec_prefix=$exec_prefix sysconfdir=$sysconfdir localstatedir=$localstatedir platform=$PLATFORM ]])
 
 dnl
 dnl update dates and versioning in doc


### PR DESCRIPTION
`bindir` defaults to `${exec_prefix}/bin`. If `exec_prefix` is not defined, `utils/bombardment` mistakenly invokes `/bin/siege` instead of the intended binary path. This change corrects the logic error.
