### PR TITLE
Fix SIGSEGV on SIGINT during warning message

### DIFF
--- a/src/crew.c
+++ b/src/crew.c
@@ -231,7 +231,7 @@ crew_join(CREW crew, BOOLEAN finish, void **payload)
     NOTIFY(FATAL, "pthread lock");
   }
 
-  if (crew->closed || crew->shutdown) {
+  if (crew->closed) {
     if ((c = pthread_mutex_unlock(&(crew->lock))) != 0) {
       NOTIFY(FATAL, "pthread unlock");
     }

--- a/src/crew.c
+++ b/src/crew.c
@@ -263,17 +263,16 @@ crew_join(CREW crew, BOOLEAN finish, void **payload)
   }
 
   crew->shutdown = TRUE;
-
-  if ((c = pthread_mutex_unlock(&(crew->lock))) != 0) {
-    NOTIFY(FATAL, "pthread_mutex_unlock");
-  }
-
   if ((c = pthread_cond_broadcast(&(crew->not_empty))) != 0) {
     NOTIFY(FATAL, "pthread broadcast");
   }
   
   if ((c = pthread_cond_broadcast(&(crew->not_full))) != 0) {
     NOTIFY(FATAL, "pthread broadcast");
+  }
+
+  if ((c = pthread_mutex_unlock(&(crew->lock))) != 0) {
+    NOTIFY(FATAL, "pthread_mutex_unlock");
   }
 
   for (x = 0; x < crew->size; x++) {
@@ -304,13 +303,26 @@ void crew_destroy(CREW crew) {
 public void 
 crew_set_shutdown(CREW this, BOOLEAN shutdown)
 {
-//  pthread_mutex_lock(&this->lock);
+  int c;
+
+  if ((c = pthread_mutex_lock(&this->lock)) != 0) {
+    NOTIFY(FATAL, "pthread lock");
+  }
   this->shutdown = shutdown;
-//  pthread_mutex_unlock(&this->lock);
   
-  pthread_cond_broadcast(&this->not_empty);
-  pthread_cond_broadcast(&this->not_full);
-  pthread_cond_broadcast(&this->empty);
+  if ((c = pthread_cond_broadcast(&this->not_empty)) != 0) {
+    NOTIFY(FATAL, "pthread broadcast");
+  }
+  if ((c = pthread_cond_broadcast(&this->not_full)) != 0) {
+    NOTIFY(FATAL, "pthread broadcast");
+  }
+  if ((c = pthread_cond_broadcast(&this->empty)) != 0) {
+    NOTIFY(FATAL, "pthread broadcast");
+  }
+  if ((c = pthread_mutex_unlock(&this->lock)) != 0) {
+    NOTIFY(FATAL, "pthread unlock");
+  }
+
   return;
 }
 
@@ -329,7 +341,18 @@ crew_get_total(CREW this)
 public BOOLEAN 
 crew_get_shutdown(CREW this)
 {
-  return this->shutdown;
+  int c;
+  BOOLEAN shutdown;
+
+  if ((c = pthread_mutex_lock(&this->lock)) != 0) {
+    NOTIFY(FATAL, "pthread lock");
+  }
+  shutdown = this->shutdown;
+  if ((c = pthread_mutex_unlock(&this->lock)) != 0) {
+    NOTIFY(FATAL, "pthread unlock");
+  }
+
+  return shutdown;
 }
 
 

--- a/src/handler.c
+++ b/src/handler.c
@@ -54,8 +54,9 @@ spin_doctor(CREW crew)
 }
 
 void 
-sig_handler(CREW crew)
+*sig_handler(void *arg)
 {
+  CREW crew = (CREW)arg;
   int gotsig = 0; 
   sigset_t  sigs;
  
@@ -81,6 +82,6 @@ sig_handler(CREW crew)
    * the siege to make up the discrepancy. 
    */
   pthread_usleep_np(501125); 
-  pthread_exit(NULL);
+  return NULL;
 }
 

--- a/src/handler.c
+++ b/src/handler.c
@@ -70,7 +70,11 @@ void
    * Now wait around for something to happen ... 
    */
   sigwait(&sigs, &gotsig);
-  my.verbose = FALSE;
+  
+  if (gotsig == SIGTERM && my.secs <= 0 && crew_get_shutdown(crew) == TRUE) {
+    return NULL;
+  }
+
   if (!my.quiet) {
     fprintf(stderr, "\nLifting the server siege...");
   }

--- a/src/handler.h
+++ b/src/handler.h
@@ -27,6 +27,6 @@
 #include <crew.h>
 
 void spin_doctor(CREW crew);
-void sig_handler(CREW crew); 
+void *sig_handler(void *arg);
 
 #endif/*HANDLER_H*/

--- a/src/main.c
+++ b/src/main.c
@@ -353,10 +353,11 @@ __config_setup(int argc, char *argv[])
     printf("\n");
     printf("================================================================\n");
     printf("WARNING: The number of users is capped at %d.%sTo increase this\n", my.limit, (my.limit>999)?" ":"  ");
-    printf("         limit, search your .siegerc file for 'limit' and change\n");
-    printf("         its value. Make sure you read the instructions there...\n");
+    printf("         limit, search your siege.conf file for 'limit' and change\n");
+    printf("         its value. Make sure you read the instructions there.\n");
+    printf("         Siege will soon proceed with %d users (unless you sigint...)\n", my.limit);
     printf("================================================================\n");
-    sleep(2);
+    sleep(10);
     my.cusers = my.limit;
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -355,7 +355,7 @@ __config_setup(int argc, char *argv[])
     printf("WARNING: The number of users is capped at %d.%sTo increase this\n", my.limit, (my.limit>999)?" ":"  ");
     printf("         limit, search your siege.conf file for 'limit' and change\n");
     printf("         its value. Make sure you read the instructions there.\n");
-    printf("         Siege will soon proceed with %d users (unless you sigint...)\n", my.limit);
+    printf("         Siege will soon proceed with %d users (unless you abort...)\n", my.limit);
     printf("================================================================\n");
     sleep(10);
     my.cusers = my.limit;

--- a/src/main.c
+++ b/src/main.c
@@ -356,7 +356,7 @@ __config_setup(int argc, char *argv[])
     printf("         limit, search your .siegerc file for 'limit' and change\n");
     printf("         its value. Make sure you read the instructions there...\n");
     printf("================================================================\n");
-    sleep(10);
+    sleep(2);
     my.cusers = my.limit;
   }
 }
@@ -495,11 +495,15 @@ main(int argc, char *argv[])
     NOTIFY(FATAL, "unable to allocate memory for %d simulated browser", my.cusers);  
   } 
 
-  if ((result = pthread_create(&cease, NULL, (void*)sig_handler, (void*)crew)) < 0) {
+  /**
+   * pthread_create retruns an errno (not necessarily a negative) on failure!
+   * should keep it != not <.
+   */
+  if ((result = pthread_create(&cease, NULL, sig_handler, (void*)crew)) != 0) {
     NOTIFY(FATAL, "failed to create handler: %d\n", result);
   }
   if (my.secs > 0) {
-    if ((result = pthread_create(&timer, NULL, (void*)siege_timer, (void*)cease)) < 0) {
+    if ((result = pthread_create(&timer, NULL, siege_timer, (void*)&cease)) != 0) {
       NOTIFY(FATAL, "failed to create handler: %d\n", result);
     } 
   }

--- a/src/main.c
+++ b/src/main.c
@@ -537,6 +537,22 @@ main(int argc, char *argv[])
   crew_join(crew, TRUE, &status);
   data_set_stop(data); 
 
+  if ((result = pthread_kill(cease, SIGTERM)) != 0 && result != ESRCH) {
+    NOTIFY(FATAL, "failed to signal handler thread: %d\n", result);
+  }
+  if ((result = pthread_join(cease, NULL)) != 0 && result != ESRCH) {
+    NOTIFY(FATAL, "failed to join handler thread: %d\n", result);
+  }
+
+  if (my.secs > 0) {
+    if ((result = pthread_cancel(timer)) != 0 && result != ESRCH) {
+      NOTIFY(FATAL, "failed to cancel timer thread: %d\n", result);
+    }
+    if ((result = pthread_join(timer, NULL)) != 0 && result != ESRCH) {
+      NOTIFY(FATAL, "failed to join timer thread: %d\n", result);
+    }
+  }
+
 #ifdef HAVE_SSL
   SSL_thread_cleanup();
 #endif

--- a/src/timer.c
+++ b/src/timer.c
@@ -28,8 +28,9 @@
 #include <joedog/boolean.h>
 
 void
-siege_timer(pthread_t handler)
+*siege_timer(void *arg)
 {
+  pthread_t handler = *((pthread_t *)arg);
   int err;
   time_t now;
   struct timespec timeout;
@@ -57,7 +58,7 @@ siege_timer(pthread_t handler)
     }
   }
   pthread_mutex_unlock(&timer_mutex);
-  return;
+  return NULL;
 }
 
 

--- a/src/timer.h
+++ b/src/timer.h
@@ -25,6 +25,6 @@
 
 #include <pthread.h>
 
-void siege_timer(pthread_t handler);
+void *siege_timer(void *arg);
  
 #endif/*TIMER_H*/


### PR DESCRIPTION
This change addresses issue #251 

helgrind drd output diff when running `siege -c12 -v -t5s 0.0.0.0:8080` notice the drop in errors from 22391 to 5607 (left is most recent version, right is my patch, third window is the server I am testing on)
<img width="1915" height="919" alt="pr_attatchment_drd_diff" src="https://github.com/user-attachments/assets/6ea86dfd-0b84-414e-a29f-70994dbf989e" />

helgrind drd output diff when running `siege -c12555 -v  -t5s 0.0.0.0:8080` errors dropped to 0 in my patch.
<img width="1915" height="919" alt="sigint_diff_drd" src="https://github.com/user-attachments/assets/43436475-f9c0-4c53-9b3b-74ef1e49cc3c" />

# The Problem
Siege sometime crashed on SIGINT due to a race condition during shutdown. Threads accessed the crew object while it was being deallocated, caused by unsynchronized state flags and signal/timer threads outliving the main execution loop, which then caused a use-after-free.

# Technical Changes
Improved Error Handling: (most) pthread related functions now check for non-zero values rather than negatives.
Clarified the Warning Message:  I hope this doesn't break the projects style, but I and many of other users found it confusing, and it had an outdated conf file name.
Synchronized State: Encapsulated shutdown flag access (get/set) within the crew mutex to eliminate data races.
Atomic Signaling: Moved condition variable broadcasts inside the lock to ensure consistent thread wakeups.
Strict Thread Lifecycle: Forced the signal and timer threads to join/terminate before crew teardown begins, preventing use-after-free errors.

# Outcome
The crash is resolved for startup-window and high-concurrency interrupts. While minor races persist in global stats, they are non fatal, and the primary shutdown-related segmentation fault is eliminated.
